### PR TITLE
Re-enable GUI after error message on install

### DIFF
--- a/UnofficialCrusaderPatchGUI/MainWindow.xaml.cs
+++ b/UnofficialCrusaderPatchGUI/MainWindow.xaml.cs
@@ -252,8 +252,25 @@ namespace UCP
             }
             catch (Exception e)
             {
-                if (!(e is TaskCanceledException || e is ThreadAbortException)) // in case of exit
+                // in case of exit
+                if (!(e is TaskCanceledException || e is ThreadAbortException))
+                {
                     MessageBox.Show(e.ToString(), Localization.Get("ui_error"));
+                }
+                else
+                {
+                    MessageBox.Show(e.ToString(), e.Message);
+                }
+
+                Dispatcher.Invoke(DispatcherPriority.Render, new Action(() =>
+                {
+                    iButtonInstall.IsEnabled = true;
+                    pButtonSearch.IsEnabled = true;
+                    pTextBoxPath.IsReadOnly = false;
+                    Version.Changes.ForEach(c => c.SetUIEnabled(true));
+                    pbSetup.Value = 0;
+                    pbLabel.Content = Localization.Get("ui_finished");
+                }));
             }
         }
 


### PR DESCRIPTION
Trigger re-enabling GUI after error message on install. Also make it so that if it's not a known error, error message will show to indicate error, instead of silently failing