### PR TITLE
Update .NET framework to latest version and update CI workflow

### DIFF
--- a/.github/workflows/dotnet-core-desktop.yml
+++ b/.github/workflows/dotnet-core-desktop.yml
@@ -1,81 +1,79 @@
 # gynt: This is based on the .NET Core Desktop starter action
 
-
 name: UCP Build
 
 on:
   workflow_dispatch:
   push:
-    branches: [ master, GUI-Update ]
+    branches: [master, GUI-Update]
   pull_request:
-    branches: [ master, GUI-Update ]
+    branches: [master, GUI-Update]
     types: [assigned, opened, edited, ready_for_review, reopened, synchronize]
 
 jobs:
-
   build:
-
     strategy:
       matrix:
         configuration: [Debug, Release]
         nuget: [latest]
 
-    runs-on: windows-latest  # For a list of available runner types, refer to
-                             # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    runs-on:
+      windows-latest # For a list of available runner types, refer to
+      # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
 
     env:
       OutputPath: ..\Output${{ matrix.configuration }}
-      Solution_Name: UnofficialCrusaderPatch.sln                      # Replace with your solution name, i.e. MyWpfApp.sln.
+      Solution_Name: UnofficialCrusaderPatch.sln # Replace with your solution name, i.e. MyWpfApp.sln.
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    
-    - name: Checkout submodules
-      run: git submodule update --init --recursive --depth 1
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    # Install the .NET Core workload
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '3.1.x'
-    
-    # Restore NuGet packages
-    - name: Setup NuGet.exe
-      uses: nuget/setup-nuget@v1
-      with:
-        nuget-version: ${{ matrix.nuget }}
-    - name: Restore NuGet packages
-      run: nuget restore $env:Solution_Name
+      - name: Checkout submodules
+        run: git submodule update --init --recursive --depth 1
 
-    # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
-    - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      # Install the .NET Core workload
+      - name: Install .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
 
-    # Execute all unit tests in the solution
-    # - name: Execute unit tests
-    #   run: dotnet test
+      # Restore NuGet packages
+      - name: Setup NuGet.exe
+        uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: ${{ matrix.nuget }}
+      - name: Restore NuGet packages
+        run: nuget restore $env:Solution_Name
 
-    # Restore the application to populate the obj folder with RuntimeIdentifiers
-    - name: Build the application
-      run: msbuild $env:Solution_Name /p:Configuration=$env:Configuration /p:OutputPath=$env:OutputPath
-      env:
-        Configuration: ${{ matrix.configuration }}
+      # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
+      - name: Setup MSBuild.exe
+        uses: microsoft/setup-msbuild@v1.1
 
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: UCP-latest-release
-        path: |
-          OutputRelease/*.dll
-          OutputRelease/*.exe
-          OutputRelease/resources
+      # Execute all unit tests in the solution
+      # - name: Execute unit tests
+      #   run: dotnet test
 
-    - name: Upload build artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: UCP-latest-debug
-        path: |
-          OutputDebug
+      # Restore the application to populate the obj folder with RuntimeIdentifiers
+      - name: Build the application
+        run: msbuild $env:Solution_Name /p:Configuration=$env:Configuration /p:OutputPath=$env:OutputPath
+        env:
+          Configuration: ${{ matrix.configuration }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: UCP-latest-release
+          path: |
+            OutputRelease/*.dll
+            OutputRelease/*.exe
+            OutputRelease/resources
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: UCP-latest-debug
+          path: |
+            OutputDebug

--- a/AICUpdater/AICUpdater.csproj
+++ b/AICUpdater/AICUpdater.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>AICUpdater</RootNamespace>
     <AssemblyName>AICUpdater</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/AICUpdater/App.config
+++ b/AICUpdater/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/CodeBlox/App.config
+++ b/CodeBlox/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/CodeBlox/CodeBlox.csproj
+++ b/CodeBlox/CodeBlox.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>CodeBlox</RootNamespace>
     <AssemblyName>CodeBlox</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/IDAParser/App.config
+++ b/IDAParser/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/IDAParser/IDAParser.csproj
+++ b/IDAParser/IDAParser.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>IDAParser</RootNamespace>
     <AssemblyName>IDAParser</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/UnofficialCrusaderPatch/App.config
+++ b/UnofficialCrusaderPatch/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/UnofficialCrusaderPatch/UnofficialCrusaderPatch.csproj
+++ b/UnofficialCrusaderPatch/UnofficialCrusaderPatch.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>UCP</RootNamespace>
     <AssemblyName>UnofficialCrusaderPatch</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -46,10 +46,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <OutputPath>bin\Debug\</OutputPath>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <PlatformTarget>x86</PlatformTarget>
     <OutputPath>bin\Release\</OutputPath>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>

--- a/UnofficialCrusaderPatchConsole/App.config
+++ b/UnofficialCrusaderPatchConsole/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/UnofficialCrusaderPatchConsole/UnofficialCrusaderPatchConsole.csproj
+++ b/UnofficialCrusaderPatchConsole/UnofficialCrusaderPatchConsole.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>UnofficialCrusaderPatchConsole</RootNamespace>
     <AssemblyName>UnofficialCrusaderPatchCLI</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/UnofficialCrusaderPatchGUI/App.config
+++ b/UnofficialCrusaderPatchGUI/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/UnofficialCrusaderPatchGUI/UnofficialCrusaderPatchGUI.csproj
+++ b/UnofficialCrusaderPatchGUI/UnofficialCrusaderPatchGUI.csproj
@@ -8,7 +8,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>UCP</RootNamespace>
     <AssemblyName>UnofficialCrusaderPatchGUI</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
@@ -29,6 +29,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
Update .NET framework for projects to 4.7.2 to latest version and update CI workflow versions to fix failing CI builds